### PR TITLE
Using export default

### DIFF
--- a/src/commands/fig-completion.ts
+++ b/src/commands/fig-completion.ts
@@ -87,9 +87,9 @@ export default class FigCompletionsCommand extends Command {
     // this.log(string)
 
     let saveJsonAsSpec = (json: any, path: string, exportTypescript: boolean = flags.lang == "ts") => {
-      let prefix = exportTypescript ? 'export const completionSpec: Fig.Spec =' : 'var completionSpec ='
+      let prefix = exportTypescript ? 'const completionSpec: Fig.Spec =' : 'var completionSpec ='
       let extension = exportTypescript ? '.ts' : '.js'
-      let final = `${prefix} ${JSON.stringify(json, null, 4)}`
+      let final = `${prefix} ${JSON.stringify(json, null, 4)} export default completionSpec`
       fs.writeFileSync(path + extension, final)
     }
 


### PR DESCRIPTION
Autocomplete was updated so that specs need to be updated as default

Updated plugin to use export default completionSpec over named export